### PR TITLE
add paste to a new file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.DS_Store
 log/
 file/
+
+paste_new_file

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Python Extract Files
 
-Extract a file with the suffix `.tar.gz` from the local path or remote path and extract to output_path.
+Extract a file with the suffix `.tar.gz` from the local path or remote path and extract to output_path. Also, all the suffix with `.gz` files will be unzipped at the same time.
+
+One more things, `pyextract` supports merging all extracted files into one new file. By default, the name of the merged file is **paste_new_file**, you can modify it with the `--paste_new_file` option.
 
 For example, a compressed package(named `123456_abc.tar.gz`) that stores the other compressed packages and files, as follows:
 
@@ -23,11 +25,12 @@ Additionally, the files in the `.tar.gz` package are compressed packages with `.
 # Usage
 
 ```Python
-➜  /Users/junbozheng/project/pyextract git:(master) ./pyextract.py --help
+➜  /Users/junbozheng/project/pyextract git:(paste) ✗ ./pyextract.py --help
 Parameter Number : 2
 Parameter Lists  : ['./pyextract.py', '--help']
 Shell Name       : ./pyextract.py
-usage: pyextract.py [-h] [--output_path OUTPUT_PATH [OUTPUT_PATH ...]] [--password PASSWORD [PASSWORD ...]] [--source_path SOURCE_PATH [SOURCE_PATH ...]] --filename FILENAME [--keep_source_file]
+usage: pyextract.py [-h] [--output_path OUTPUT_PATH [OUTPUT_PATH ...]] [--password PASSWORD [PASSWORD ...]] [--source_path SOURCE_PATH [SOURCE_PATH ...]]
+                    [--paste_new_file PASTE_NEW_FILE [PASTE_NEW_FILE ...]] --filename FILENAME [--keep_source_file]
 
 Extract a file with the suffix `.tar.gz` from the local path or remote path and extract to output_path.
 
@@ -39,6 +42,8 @@ optional arguments:
                         extract packet and chmod with user password
   --source_path SOURCE_PATH [SOURCE_PATH ...]
                         extract packet source packet
+  --paste_new_file PASTE_NEW_FILE [PASTE_NEW_FILE ...]
+                        extract packet and paste to a new file
   --filename FILENAME   extract packet filename, the default file suffix is .tar.gz, such as: log.tar.gz
   --keep_source_file    keep source file in local path, copy to a new file without remove it if is true
 ```

--- a/pyextract.py
+++ b/pyextract.py
@@ -14,6 +14,7 @@ remote_path = "/sdcard/Android/data/com.mi.health/files/log/devicelog"
 local_path = "Downloads"
 output_path = "./file"
 output_file = "file.tar.gz"
+paste_new_file = "./paste_new_file"
 
 tmp_log = "tmp.log"
 
@@ -23,6 +24,31 @@ def get_full_path(path):
         for file in files:
             if file == tmp_log:
                 return os.path.join(root, file)
+
+
+def remove_all_suffix_gz_file(path):
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            if os.path.splitext(file)[-1] == ".gz":
+                os.remove(os.path.join(root, file))
+
+
+def paste_all_file(path, args):
+    file_list = os.listdir(path)
+    file_list.sort()
+    print("prepare to paste file list %s" % file_list)
+
+    if os.path.exists(args.paste_new_file):
+        print("file exit and remove")
+        os.remove(args.paste_new_file)
+
+    cmd = "cat "
+    for file in file_list:
+        cmd += os.path.join(path, file) + " "
+
+    cmd += ">" + " " + args.paste_new_file
+    print("cmd %s" % cmd)
+    os.system(cmd)
 
 
 def pull_from_source_path(args):
@@ -115,6 +141,11 @@ if __name__ == '__main__':
                            nargs='+',
                            default=local_path,
                            help="extract packet source packet")
+    arg_parse.add_argument('--paste_new_file',
+                           type=str,
+                           nargs='+',
+                           default=paste_new_file,
+                           help="extract packet and paste to a new file")
     arg_parse.add_argument(
         '--filename',
         type=str,
@@ -164,3 +195,9 @@ if __name__ == '__main__':
 
     # gunzip all *.gz files under path
     gunzip_all(path)
+
+    # remove unused .gz files
+    remove_all_suffix_gz_file(path)
+
+    # paste all file to a new file
+    paste_all_file(path, args)


### PR DESCRIPTION
`pyextract` supports merging all extracted files into one new file. By default, the name of the merged file is **paste_new_file**, you can modify it with the `--paste_new_file` option.

Signed-off-by: Junbo Zheng <3273070@qq.com>