### PR TITLE
fix small typo and warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 log/
 file/
 
-paste_new_file
 .idea/
 merged.log

--- a/pyextract.py
+++ b/pyextract.py
@@ -106,10 +106,10 @@ def pull_from_source_path(args):
 def gunzip_all(path):
     if os.path.exists(path):
         dirs = os.listdir(path)
-        for dir in dirs:
-            if '.gz' in dir:
-                filename = dir.replace(".gz", "")
-                gzip_file = gzip.GzipFile(path + '/' + dir)
+        for file in dirs:
+            if '.gz' in file:
+                filename = file.replace(".gz", "")
+                gzip_file = gzip.GzipFile(path + '/' + file)
                 with open(path + "/" + filename, 'wb+') as f:
                     f.write(gzip_file.read())
     print("gunzip all finish")

--- a/pyextract.py
+++ b/pyextract.py
@@ -61,7 +61,7 @@ def merge_logfiles(path, args):
 
 
 def pull_from_source_path(args):
-    if (args.source_path[0] == "phone"):
+    if args.source_path[0] == "phone":
         args.source_path = default_cli_parameters.remote_path
         adb_cmd = "adb pull " + args.source_path + " " + "./"
         print(adb_cmd)
@@ -93,7 +93,7 @@ def pull_from_source_path(args):
     output = args.filename[0] + "_" + default_cli_parameters.output_file
     output = os.path.join(path, output)
 
-    if (args.keep_source_file):
+    if args.keep_source_file:
         print("copy to %s" % output)
         shutil.copyfile(file, output)
     else:


### PR DESCRIPTION
fix small typo and warning:

1. fix warning by CLion
2. remove unused brackets
3. gitignore: remove unused file

Signed-off-by: Junbo Zheng <3273070@qq.com>