### PR TITLE
fix tar: Error is not recoverable: exiting now

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -274,10 +274,13 @@ class LogTools:
         if not os.path.exists(self.__cli_parser.output_path):
             os.makedirs(self.__cli_parser.output_path)
 
-        cmd = (
-            "tar -xzvf " + self.log_packet_path + " -C " + self.__cli_parser.output_path
-        )
-        print(Highlight.Convert("extract") + " by command " + cmd)
+        cmd = "gzip -d " + self.log_packet_path
+        print(Highlight.Convert("gzip") + " by command " + cmd)
+        ShellRunner.command_run(cmd)
+
+        tar_package = self.log_packet_path.replace(".gz", "")
+        cmd = "tar -xvf " + tar_package + " -C " + self.__cli_parser.output_path
+        print(Highlight.Convert("tar") + " by command " + cmd)
         if ShellRunner.command_run(cmd) != 0:
             return -1
 
@@ -285,8 +288,8 @@ class LogTools:
         if ShellRunner.command_run(cmd, self.__cli_parser.password) != 0:
             return -1
 
-        # file is temp, need to remove
-        os.remove(self.log_packet_path)
+        # tar_package is tmp file, since it's has replaced from .tar.gz to .tar, let's remove it
+        os.remove(tar_package)
 
         # find log files dir path
         if self.__find_logfiles_path__() != 0:


### PR DESCRIPTION
fix tar: Error is not recoverable: exiting now

file layout
```
➜  /home/mi/Downloads/1 tar -ztvf _data_tmp_19971_log.tar.gz
tar: Removing leading `/' from member names
drwxrwxrwx root/0            0 2098-01-01 08:00 /log/offlinelog/
-rwxrwxrwx root/0      1212830 2025-01-24 12:07 /log/offlinelog/tmp.log
```

before
```
➜  /home/mi/Downloads/1 19971
Parameter Number : 7
Shell Name       : /home/mi/xiaomi/pyextract/pyextract.py
output_path      : ./file
source_path      : ['.']
filename         : ['19971']
purge_source_file: False
merge_file       : None
pull ['./_data_tmp_19971_log.tar.gz'] from .
copy to ./19971_file.tar.gz
output file ./19971_file.tar.gz
extract by command sudo tar -xzvf ./19971_file.tar.gz -C ./file
tar: Removing leading `/' from member names
/log/offlinelog/
/log/offlinelog/tmp.log

gzip: stdin: decompression OK, trailing garbage ignored
tar: Child returned status 2
tar: log/offlinelog: time stamp 2098-01-01 08:00:00 is 2301666445.577567266 s in the future
tar: Error is not recoverable: exiting now
failure
```

after
```
➜  /home/mi/Downloads/1 19971
Parameter Number : 7
Shell Name       : /home/mi/xiaomi/pyextract/pyextract.py
output_path      : ./file
source_path      : ['.']
filename         : ['19971']
purge_source_file: False
merge_file       : None
pull ['./_data_tmp_19971_log.tar.gz'] from .
copy to ./19971_file.tar.gz
output file ./19971_file.tar.gz
gzip by command gzip -d ./19971_file.tar.gz

gzip: ./19971_file.tar.gz: decompression OK, trailing garbage ignored
tar by command tar -xvf ./19971_file.tar -C ./file
tar: Removing leading `/' from member names
/log/offlinelog/
/log/offlinelog/tmp.log
tar: log/offlinelog: time stamp 2098-01-01 08:00:00 is 2301666315.048867482 s in the future

gunzip all finish
Coredump not found
merge file list ['tmp.log']
merge file by command cat /home/mi/Downloads/1/file/log/offlinelog/tmp.log > /home/mi/Downloads/1/19971.log
clear exist file ./file by command sudo rm -rf ./file
Successful
```

Reference: https://stackoverflow.com/questions/3950839/tar-error-is-not-recoverable-exiting-now

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>