### PR TITLE
support extract the filename without suffix && Print out the merge_file that is not set

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -120,15 +120,21 @@ class CLIParametersParser:
 
         self.__cli_args = arg_parser.parse_args()
 
+        # extract the filename without suffix
+        pattern = r"^(.*?)\.tar.*\.gz$"
+        match = re.match(pattern, self.filename[0])
+        if match:
+            self.filename[0] = match.group(1)
+
+        # With the input filename parameter as merge file if merge file is not specified
+        if self.merge_file is None:
+            self.merge_file = os.path.join(os.getcwd(), self.filename[0] + ".log")
+
         print("output_path      :", self.output_path)
         print("source_path      :", self.source_path)
         print("filename         :", self.filename)
         print("purge_source_file:", self.purge_source_file)
         print("merge_file       :", self.merge_file)
-
-        # With the input filename parameter as merge file if merge file is not specified
-        if self.merge_file is None:
-            self.merge_file = os.path.join(os.getcwd(), self.filename[0] + ".log")
 
     def __getattr__(self, item):
         return self.__cli_args.__getattribute__(item)


### PR DESCRIPTION
1. support extract the filename without suffix
    
2. Print out the merge_file that is not set

example：
```
➜  ./pyextract.py -s . -f _data_tmp_19971_log.tar.gz
Parameter Number : 7
Parameter Lists  : ['./pyextract.py', '-P', 'shuailong', '-s', '.', '-f', '_data_tmp_19971_log.tar.gz']
Shell Name       : ./pyextract.py
output_path      : ./file
source_path      : ['.']
filename         : ['_data_tmp_19971_log']
purge_source_file: False
merge_file       : /home/yushuailong/workspace/other/pyextract/_data_tmp_19971_log.log
pull ['./_data_tmp_19971_log.tar.gz'] from .
copy to ./_data_tmp_19971_log_file.tar.gz
output file ./_data_tmp_19971_log_file.tar.gz
gzip by command gzip -d ./_data_tmp_19971_log_file.tar.gz
tar by command tar -xvf ./_data_tmp_19971_log_file.tar -C ./file
tar: 从成员名中删除开头的“/”
/log/offlinelog/
/log/offlinelog/log1381.gz
/log/offlinelog/tmp.log
/log/offlinelog/log1378.gz
/log/offlinelog/log1379.gz
/log/offlinelog/log1380.gz
tar: log/offlinelog：时间戳 2098-01-01 08:00:00 是未来的 2299316107.925606196 秒之后
[sudo] yushuailong 的密码： 
gunzip all finish
Coredump not found
merge file list ['log1378', 'log1379', 'log1380', 'log1381', 'tmp.log']
merge file by command cat /home/yushuailong/workspace/other/pyextract/file/log/offlinelog/log1378 /home/yushuailong/workspace/other/pyextract/file/log/offlinelog/log1379 /home/yushuailong/workspace/other/pyextract/file/log/offlinelog/log1380 /home/yushuailong/workspace/other/pyextract/file/log/offlinelog/log1381 /home/yushuailong/workspace/other/pyextract/file/log/offlinelog/tmp.log > /home/yushuailong/workspace/other/pyextract/_data_tmp_19971_log.log
clear exist file ./file by command sudo rm -rf ./file
Successful

```