### PR TITLE
pyextract.py: remove unnecessary log output

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -56,7 +56,6 @@ class ShellRunner:
 class CLIParametersParser:
     def __init__(self):
         print("Parameter Number :", len(sys.argv))
-        print("Parameter Lists  :", str(sys.argv))
         print("Shell Name       :", str(sys.argv[0]))
 
         arg_parser = argparse.ArgumentParser(


### PR DESCRIPTION
pyextract.py: remove unnecessary log output
    
since this could print personal privacy, it is stupid.
    
Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>