### PR TITLE
fix: file name sort error

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -311,7 +311,7 @@ class LogTools:
     # merge all file to a new file
     def merge_logfiles(self):
         file_list = os.listdir(self.log_dir_path)
-        file_list.sort()
+        file_list.sort(key=lambda name: (len(name), name))
         print(Highlight.Convert("merge") + " file list %s" % file_list)
 
         if os.path.exists(self.__cli_parser.merge_file):


### PR DESCRIPTION
日志文件的序号长度不同时，会导致排序错误，造成合并后的文件不符合预期。如下图
![image](https://github.com/user-attachments/assets/241925f4-aa87-4396-ac8c-17300c2cdab1)
