### PR TITLE
pyextract: add get stack information from logging message

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -341,8 +341,8 @@ class LogTools:
 
 
 def CHECK_ERROR_EXIT(ret):
-    if ret != 0:
-        log.debug(Highlight.Convert("failure", Highlight.RED))
+    if ret:
+        log.error(Highlight.Convert("failure", Highlight.RED), stack_info=True)
         exit(ret)
 
 

--- a/pyextract.py
+++ b/pyextract.py
@@ -172,9 +172,11 @@ class LogTools:
                 return -1
 
         cmd = "sudo rm -rf " + self.__cli_parser.output_path
+        # fmt: off
         log.debug(
             Highlight.Convert("clear") + " exist file %s by command %s",
             self.__cli_parser.output_path, cmd)
+        # fmt: on
         return ShellRunner.command_run(cmd, self.__cli_parser.password)
 
     def pull_packet(self):
@@ -205,9 +207,11 @@ class LogTools:
         if len(result) == 0:
             return -1
 
+        # fmt: off
         log.debug(
             Highlight.Convert("pull") + " %s from %s",
             result, self.__cli_parser.source_path[0])
+        # fmt: on
 
         if len(result) > 1:
             index = input("Please input the file index you want to extract:\n")


### PR DESCRIPTION
1. pyextract: add ignore format section

Since it format wrong format print

2. pyextract: add get stack information from logging message
```
stack_info, which defaults to False. If true, stack information is added to the logging
message, including the actual logging call.

Note that this is not the same stack information as that displayed through specifying
exc_info: The former is stack frames from the bottom of the stack up to the logging call
in the current thread, whereas the latter is information about stack frames which have
been unwound, following an exception, while searching for exception handlers.
```
reference:
- https://docs.python.org/3/library/logging.html#logging.Logger.debug

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>