### PR TITLE
pyextract: add crash.txt file to special_file_prefix to dump

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -45,7 +45,7 @@ class DefaultCLIParameters:
     output_file = "file.tar.gz"
     filter_pattern = "log\\d*|tmp.log"
     tmp_log = "tmp.log"
-    special_file_prefix = ["core-", "minidump"]
+    special_file_prefix = ["core-", "minidump", "crash.txt"]
 
 
 class ShellRunner:


### PR DESCRIPTION
pyextract: add crash.txt file to special_file_prefix to dump

Signed-off-by: Junbo Zheng <zhengjunbo1@xiaomi.com>