### PR TITLE
pyextract: only check `crash` prefix for crash log

### DIFF
--- a/pyextract.py
+++ b/pyextract.py
@@ -45,7 +45,7 @@ class DefaultCLIParameters:
     output_file = "file.tar.gz"
     filter_pattern = "log\\d*|tmp.log"
     tmp_log = "tmp.log"
-    special_file_prefix = ["core-", "minidump", "crash.txt"]
+    special_file_prefix = ["core-", "minidump", "crash"]
 
 
 class ShellRunner:


### PR DESCRIPTION
pyextract: only check `crash` prefix for crash log 

Signed-off-by: Junbo Zheng <3273070@qq.com>
