### PR TITLE
miwear/log: add print help message without cli parameter

### DIFF
--- a/miwear/log.py
+++ b/miwear/log.py
@@ -129,6 +129,10 @@ class CLIParametersParser:
             help="special log file name(default: tmp.log)",
         )
 
+        if (len(sys.argv)) <= 1:
+            arg_parser.print_help()
+            sys.exit(0)
+
         self.__cli_args = arg_parser.parse_args()
         if self.__cli_args.version:
             print("miwear_log version %s" % __version__)


### PR DESCRIPTION
miwear/log: add print help message without cli parameter

```
➜  /home/mi/xiaomi/miwear/miwear [25-12-08_17:25:42] git:(log) ./log.py
usage: log.py [-h] [--version] [-o OUTPUT_PATH [OUTPUT_PATH ...]] [-s SOURCE_PATH [SOURCE_PATH ...]] [-m [MERGE_FILE]] [-f FILENAME] [-p] [-F FILTER_PATTERN] [-l LOG]

Extract a file with the suffix `.tar.gz` from the source path or remote path and extract to output_path.

options:
  -h, --help            show this help message and exit
  --version             Show miwear_log version and exit.
  -o OUTPUT_PATH [OUTPUT_PATH ...], --output_path OUTPUT_PATH [OUTPUT_PATH ...]
                        extract packet output path
  -s SOURCE_PATH [SOURCE_PATH ...], --source_path SOURCE_PATH [SOURCE_PATH ...]
                        extract packet from source path
  -m [MERGE_FILE], --merge_file [MERGE_FILE]
                        extract packet and merge to a new file
  -f FILENAME, --filename FILENAME
                        extract packet filename, the default file suffix is .tar.gz, such as: log.tar.gz
  -p, --purge_source_file
                        purge source file if is true
  -F FILTER_PATTERN, --filter_pattern FILTER_PATTERN
                        filter the files to be merged
  -l LOG, --log LOG     special log file name(default: tmp.log)
➜  /home/mi/xiaomi/miwear/miwear [25-12-08_17:25:44] git:(log)
```

Signed-off-by: Junbo Zheng <3273070@qq.com>
