### PR TITLE
serialtool: add batch command execution with interval and count support

### DIFF
--- a/test/command.txt
+++ b/test/command.txt
@@ -1,0 +1,7 @@
+uptime
+
+ps
+
+hello
+
+free


### PR DESCRIPTION
serialtool: add batch command execution with interval and count support

Key Features:

- Add interval and count parameters to send_batch_commands method
- Support repeated batch execution with configurable timing
- Improve progress display with run counter and command tracking
- Fix miniterm mode detection to avoid conflicts with batch mode
- Add --response(-r) option for controlling response data display
- Update command-line help documentation and usage examples

Technical Details:
- Batch execution supports infinite loop (-1) or specified count
- 0.2s interval between commands within batch, configurable between batches
- Optional response processing/display (disabled by default to avoid terminal interference)
- Add test command file test/command.txt for batch execution testing

Signed-off-by: Junbo Zheng <3273070@qq.com>