### PR TITLE
docs: add miwear_serial tool documentation with comprehensive usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ A comprehensive Python Miwear toolkit to extract and process archive log files.
 
 - Supports batch extraction of `.tar.gz` , `.zip` and `.gz` files.
 - Command-line tools for log processing, validation, merging and unzipping.
+- Serial command sender for interacting with serial devices (requires `pyserial`).
 - Designed for automation and integration into your workflow.
-- No external dependencies, pure Python standard libraries.
+- No external dependencies for log processing tools (pure Python standard libraries).
+- `pyserial` required for serial communication functionality.
 
 ## Installation
 
@@ -15,6 +17,12 @@ Install the latest release from `PyPI`:
 
 ```bash
 pip(3) install miwear
+```
+
+If you plan to use the serial command sender tool, also install `pyserial`:
+
+```bash
+pip(3) install pyserial
 ```
 
 Alternatively, install from source:
@@ -34,6 +42,7 @@ After installation, you get several standalone CLI tools:
 - `miwear_gz` : Unzip and merge `.gz` log files.
 - `miwear_tz` : Specialized extraction for `.tar.gz`.
 - `miwear_uz` : Versatile archive decompression utility.
+- `miwear_serial` : Serial command sender for interacting with serial devices (requires `pyserial`).
 
 ## Usage Examples
 
@@ -66,6 +75,92 @@ miwear_tz --path ./logs
 ```bash
 miwear_uz --path ./logs
 ```
+
+### 6. Serial Command Sender
+
+The `miwear_serial` tool requires the `pyserial` library. Install it with:
+
+```bash
+pip(3) install pyserial
+```
+
+#### Basic Usage
+
+Open miniterm terminal (default behavior):
+
+```bash
+miwear_serial -p /dev/ttyACM0 -b 921600
+```
+
+Send a single command:
+
+```bash
+miwear_serial -p /dev/ttyUSB1 -b 115200 -c "ps"
+```
+
+Send a single command with response processing:
+
+```bash
+miwear_serial -p /dev/ttyUSB1 -b 115200 -c "ps" -r
+```
+
+#### Periodic Command Sending
+
+Send command every 1 second:
+
+```bash
+miwear_serial -p /dev/ttyACM1 -i 1.0 -c "ps"
+```
+
+Send command 5 times with 2-second interval:
+
+```bash
+miwear_serial -p /dev/ttyACM1 -i 2.0 -c "ps" --count 5
+```
+
+#### Batch Command Execution
+
+Send batch commands from file once:
+
+```bash
+miwear_serial -f commands.txt
+```
+
+Send batch commands every 2 seconds:
+
+```bash
+miwear_serial -f commands.txt -i 2.0
+```
+
+Send batch commands 5 times, every 2 seconds:
+
+```bash
+miwear_serial -f commands.txt -i 2.0 --count 5
+```
+
+#### Logging
+
+Save all output to log file (default: miwear.log):
+
+```bash
+miwear_serial -p /dev/ttyACM0 -b 921600 -s
+```
+
+Save to specific log file:
+
+```bash
+miwear_serial -p /dev/ttyACM0 -b 921600 -s log.txt
+```
+
+#### Interactive Mode
+
+For interactive command sending, use miniterm (default when no command specified):
+
+```bash
+miwear_serial -p /dev/ttyACM0 -b 921600
+```
+
+Press Ctrl+] to exit miniterm.
 
 **Each tool includes a `--help` option to display supported parameters and usage:**
 


### PR DESCRIPTION
docs: add miwear_serial tool documentation with comprehensive usage examples

- Document serial command sender feature and pyserial dependency
- Add miwear_serial CLI tool description
- Include usage examples for basic, periodic, batch, and logging modes

Signed-off-by: Junbo Zheng <3273070@qq.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added README documentation for the miwear_serial CLI, with examples for basic, periodic, batch, logging, and interactive modes. Updated the CLI tools list and usage guidance to include serial support.

- **Dependencies**
  - Documented pyserial requirement for serial functionality and included an install snippet.

<sup>Written for commit 9e93b6bbaa1052b965d8b490067f7d28950dc3fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

