### PR TITLE
miwear/ymodem: rename command-line options for clarity

### DIFF
--- a/miwear/ymodem.py
+++ b/miwear/ymodem.py
@@ -839,6 +839,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if not args.pull and not args.push:
+        print("Error: must specify --push or --pull")
+        return
+
     print(f"{V}ymodem transfer init, a moment please...{N}")
 
     fd_serial = serial.Serial(args.port, baudrate=args.baudrate)
@@ -860,19 +865,12 @@ def main():
         fd_serial.write(("sb %s\r\n" % (recvfile)).encode())
         # tmp = fd_serial.read(len(("sb %s\r\n" % (recvfile)).encode()))
     else:
-        if args.push:
-            if len(args.push) < 2:
-                print(
-                    "Error: --push requires at least one local file and a remote path"
-                )
-                fd_serial.close()
-                return
-            remote_path = args.push[-1]
-            local_files = args.push[:-1]
-            cmd = ("rb -f %s\r\n" % (remote_path)).encode()
-        else:
-            cmd = ("rb\r\n").encode()
-
+        if len(args.push) < 2:
+            print("Error: --push requires at least one local file and a remote path")
+            return
+        remote_path = args.push[-1]
+        local_files = args.push[:-1]
+        cmd = ("rb -f %s\r\n" % (remote_path)).encode()
         fd_serial.write(cmd)
         sleep(0.5)
         # length = fd_serial.read(len(cmd))
@@ -889,12 +887,6 @@ def main():
 
     if args.pull:
         tool.base_path = local_path
-    elif args.push:
-        pass  # local_files defined above
-    else:
-        print("Error: must specify --push or --pull")
-        fd_serial.close()
-        return
 
     tool.progress("ymodem start receiving\n" if args.pull else "ymodem start sending\n")
     if args.pull:

--- a/miwear/ymodem.py
+++ b/miwear/ymodem.py
@@ -806,26 +806,24 @@ def main():
     )
 
     parser.add_argument(
-        "-r",
-        "--recvfrom",
+        "--pull",
         type=str,
         nargs="*",
         help="""
-            recvfile from board path
+            pull from board path
             like this:
-                ./ymodem.py -r <file1 [file2 [file 3]...]> -p /dev/ttyUBS0
+                ./ymodem.py --pull <file1 [file2 [file 3]...]> -p /dev/ttyUBS0
             """,
     )
 
     parser.add_argument(
-        "-s",
-        "--sendto",
+        "--push",
         type=str,
         nargs=1,
         help="""
             send file to board path
             like this:
-                ./ymodem.py -s <path on board> -t /dev/ttyUBS0 <file1 [file2 [file3] ...]>
+                ./ymodem.py --push <path on board> -t /dev/ttyUBS0 <file1 [file2 [file3] ...]>
             """,
     )
 
@@ -852,16 +850,16 @@ def main():
         sleep(0.5)
         fd_serial.reset_input_buffer()
 
-        if args.recvfrom:
+        if args.pull:
             recvfile = ""
-            for i in args.recvfrom:
+            for i in args.pull:
                 recvfile += i + " "
 
             fd_serial.write(("sb %s\r\n" % (recvfile)).encode())
             # tmp = fd_serial.read(len(("sb %s\r\n" % (recvfile)).encode()))
         else:
-            if args.sendto:
-                cmd = ("rb -f %s\r\n" % (args.sendto[0])).encode()
+            if args.push:
+                cmd = ("rb -f %s\r\n" % (args.push[0])).encode()
             else:
                 cmd = ("rb\r\n").encode()
 

--- a/miwear/ymodem.py
+++ b/miwear/ymodem.py
@@ -859,6 +859,7 @@ def main():
             print("Error: --pull requires at least one remote file and a local path")
             fd_serial.close()
             return
+
         local_path = args.pull[-1]
         remote_files = args.pull[:-1]
         recvfile = " ".join(remote_files)
@@ -867,7 +868,9 @@ def main():
     else:
         if len(args.push) < 2:
             print("Error: --push requires at least one local file and a remote path")
+            fd_serial.close()
             return
+
         remote_path = args.push[-1]
         local_files = args.push[:-1]
         cmd = ("rb -f %s\r\n" % (remote_path)).encode()

--- a/miwear/ymodem.py
+++ b/miwear/ymodem.py
@@ -852,6 +852,7 @@ def main():
     if args.pull:
         if len(args.pull) < 2:
             print("Error: --pull requires at least one remote file and a local path")
+            fd_serial.close()
             return
         local_path = args.pull[-1]
         remote_files = args.pull[:-1]
@@ -864,6 +865,7 @@ def main():
                 print(
                     "Error: --push requires at least one local file and a remote path"
                 )
+                fd_serial.close()
                 return
             remote_path = args.push[-1]
             local_files = args.push[:-1]
@@ -891,6 +893,7 @@ def main():
         pass  # local_files defined above
     else:
         print("Error: must specify --push or --pull")
+        fd_serial.close()
         return
 
     tool.progress("ymodem start receiving\n" if args.pull else "ymodem start sending\n")


### PR DESCRIPTION
# Overview

This PR refactors the ymodem.py script to provide a cleaner, more intuitive command-line interface for serial file transfers, inspired by adb push/pull commands. The changes improve usability by standardizing argument handling and removing legacy code paths.
Changes Made
1. Rename Command-Line Options for Clarity (Commit: 6de25de)
- Renamed -r/--recvfrom to --pull
- Renamed -s/--sendto to --push
- Updated help texts and variable references accordingly
- Why: The new names are more descriptive and align with common CLI conventions
2. Change --push and --pull to adb-like Syntax (Commit: ac2bbb4)
- Modified --push to accept local_files... remote_path (adb-style)
- Modified --pull to accept remote_files... local_path (adb-style)
- Added base_path support in the ymodem class for custom receive directories
- Added argument validation for minimum required parameters
- Updated help texts with new usage examples
- Why: Provides a more intuitive interface where source comes before destination, similar to familiar tools
3. Remove filelist Positional Arg, Enforce --push/--pull Usage (Commit: 41000f5)
- Removed the positional filelist argument from argparse
- Removed non-serial mode code (stdin/stdout transfers)
- Enforced that users must specify --push or --pull for all operations
- Simplified code by removing conditional branches based on args.port (always true due to default)
- Why: Eliminates ambiguity in usage and focuses the tool on its primary use case (serial transfers)
# Breaking Changes
- Removed: Support for stdin/stdout file transfers (non-serial mode)
- Removed: Positional filelist argument
- Changed: Argument syntax for --push and --pull options
- Required: Must specify either --push or --pull when running the script

# New Usage Examples
## Push local files to remote device
```
./ymodem.py --push file1.txt file2.txt /remote/dir -p /dev/ttyACM1
```
## Pull remote files to local directory
```
./ymodem.py --pull remote_file1.txt remote_file2.txt /local/dir -p /dev/ttyACM1
```

# Testing

- Verified argument parsing with --help
- Checked syntax with python3 -m py_compile
- Ensured error handling for invalid argument combinations
- Confirmed serial communication setup works correctly

# Impact

These changes make the tool more user-friendly and maintainable by providing a consistent, adb-like interface while removing unused code paths. The script now has a single, clear purpose: serial file transfers with intuitive argument ordering.

Signed-off-by: Junbo Zheng <3273070@qq.com>