### PR TITLE
fix: log.py extraction and build script issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ flake8 . --count --show-source --statistics
 
 black --check --diff .
 
-./miwear/log.py -s ./test --filename 123
+./miwear/log.py --filename ./test/123.tar.gz
 
 ./miwear/targz.py --path test
 
@@ -16,4 +16,4 @@ black --check --diff .
 
 md5sum -c test/123.md5
 
-./miwear/log.py -s test -f ./test/456（1）.tar.gz
+./miwear/log.py ./test/456（1）.tar.gz

--- a/miwear/__init__.py
+++ b/miwear/__init__.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"

--- a/miwear/log.py
+++ b/miwear/log.py
@@ -376,15 +376,30 @@ class LogTools:
             shutil.copy(special_file, des_path)
         return 0
 
+    def __is_gzip_file__(self, filepath):
+        try:
+            with open(filepath, "rb") as f:
+                magic = f.read(2)
+                return magic == b"\x1f\x8b"  # gzip magic bytes
+        except Exception:
+            return False
+
     def extract_packet(self):
         if not os.path.exists(self.__cli_parser.output_path):
             os.makedirs(self.__cli_parser.output_path)
 
-        cmd = "gzip -d " + self.log_packet_path
-        log.debug(Highlight.Convert("gzip") + " by command " + cmd)
-        ShellRunner.command_run(cmd)
+        if self.__is_gzip_file__(self.log_packet_path):
+            cmd = "gzip -d " + self.log_packet_path
+            log.debug(Highlight.Convert("gzip") + " by command " + cmd)
+            ShellRunner.command_run(cmd)
+            tar_package = self.log_packet_path.replace(".gz", "")
+        else:
+            log.debug(
+                Highlight.Convert("skip gzip")
+                + " - file is not gzip compressed, treating as tar archive"
+            )
+            tar_package = self.log_packet_path
 
-        tar_package = self.log_packet_path.replace(".gz", "")
         cmd = "tar -xvf " + tar_package + " -C " + self.__cli_parser.output_path
         log.debug(Highlight.Convert("tar") + " by command " + cmd)
 
@@ -403,8 +418,11 @@ class LogTools:
             )
             return -1
 
-        # tar_package is tmp file, since it's has replaced from .tar.gz to .tar, let's remove it
-        os.remove(tar_package)
+        if (
+            tar_package != self.log_packet_path
+            or not self.__cli_parser.purge_source_file
+        ):
+            os.remove(tar_package)
 
         # find log files dir path
         if self.__find_logfiles_path__() != 0:


### PR DESCRIPTION
## Summary
- Fix extraction of non-gzip tar archives in log.py
- Fix build.sh unrecognized arguments error
- Bump version to 0.0.13
## Changes
### log.py: fix extraction of non-gzip tar archives
- Add `__is_gzip_file__` to detect actual file format by magic bytes (`\x1f\x8b`)
- Skip gzip decompression for plain tar files (some `.tar.gz` files are actually uncompressed tar)
- Fix temp file cleanup logic
### build.sh: fix unrecognized arguments error
- Remove invalid `-s` argument from log.py invocation
### Version bump
- Update version to 0.0.13
## Test
Tested with non-gzip tar archive extraction:
```bash
python3 miwear/log.py -f _data_tmp_28155_log.tar.gz
Successfully extracted and merged log files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix tar extraction in `miwear/log.py` by detecting real gzip files and skipping decompression for plain tar archives. Also fix `build.sh` arg error and bump to 0.0.13.

- **Bug Fixes**
  - `miwear/log.py`: Add `__is_gzip_file__` (magic byte check) and only run gzip when needed.
  - `miwear/log.py`: Correct temp file cleanup after extraction.
  - `build.sh`: Remove invalid `-s` flag and fix `--filename` usage.

<sup>Written for commit 48005350ba6e2818799ce94b6f12923e1cdef148. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

