### PR TITLE
Minor fix

### DIFF
--- a/miwear/check.py
+++ b/miwear/check.py
@@ -1116,6 +1116,7 @@ Mode Description:
 
     # Mode selection
     parser.add_argument(
+        "-m",
         "--mode",
         choices=["dup", "unused", "both"],
         default="dup",

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -433,10 +433,16 @@ def _is_referenced_in_content(stem: str, content: str) -> bool:
     if f'"{stem}"' in content or f"'{stem}'" in content:
         return True
 
-    # Numbered stem: anim0 -> check for "anim%d", "anim%s", "anim%02d" etc.
-    # Strips trailing digits: anim0->anim, frame01->frame, icon123->icon
+    # Numbered stem: Measuring45 -> base_stem "Measuring"
+    # Matches: "Measuring%d", "Measuring%02d", "/Measuring", '"Measuring"'
+    # Covers both format-string patterns and prefix_name/suffix_name patterns
+    # like: dsc.prefix_name = "/path/Measuring"; dsc.suffix_name = ".bin";
     base_stem = re.sub(r"\d+$", "", stem)
     if base_stem and base_stem != stem:
+        if f"/{base_stem}" in content:
+            return True
+        if f'"{base_stem}"' in content or f"'{base_stem}'" in content:
+            return True
         if re.search(rf'["\'/]{re.escape(base_stem)}%[dsx0-9]', content):
             return True
 
@@ -479,7 +485,10 @@ def find_unused_resources(
     stem_to_base: Dict[str, str] = {}
     for bin_path in bin_files:
         basename = os.path.basename(bin_path)
-        stem = os.path.splitext(basename)[0]
+        raw_stem = os.path.splitext(basename)[0]
+        stem = raw_stem.strip("_ \t0123456789")
+        if not stem:
+            stem = raw_stem
         stem_to_paths[stem].append(bin_path)
         base = re.sub(r"\d+$", "", stem)
         if base and base != stem:

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -486,7 +486,7 @@ def find_unused_resources(
     for bin_path in bin_files:
         basename = os.path.basename(bin_path)
         raw_stem = os.path.splitext(basename)[0]
-        stem = raw_stem.strip("_ \t0123456789")
+        stem = raw_stem.strip("_ \t")
         if not stem:
             stem = raw_stem
         stem_to_paths[stem].append(bin_path)

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -475,10 +475,15 @@ def find_unused_resources(
 
     # Build stem -> [resource_paths] mapping
     stem_to_paths: Dict[str, List[str]] = defaultdict(list)
+    # Pre-compute base stems (strip trailing digits) for numbered files
+    stem_to_base: Dict[str, str] = {}
     for bin_path in bin_files:
         basename = os.path.basename(bin_path)
         stem = os.path.splitext(basename)[0]
         stem_to_paths[stem].append(bin_path)
+        base = re.sub(r"\d+$", "", stem)
+        if base and base != stem:
+            stem_to_base[stem] = base
 
     referenced_files: Set[str] = set()
     match_details: Dict[str, str] = {}
@@ -511,12 +516,28 @@ def find_unused_resources(
             except (IOError, OSError):
                 continue
 
-            newly_matched = []
+            # Fast pre-filter: only check stems that appear as
+            # substring in this file (plain `in` is ~100x faster
+            # than regex).  Also include stems whose base_stem
+            # appears (for numbered files like anim0 -> anim).
+            candidates = set()
             for stem in unmatched_stems:
+                if stem in content:
+                    candidates.add(stem)
+                elif stem in stem_to_base:
+                    base = stem_to_base[stem]
+                    if base in content:
+                        candidates.add(stem)
+
+            if not candidates:
+                continue
+
+            newly_matched = []
+            rel_code = os.path.relpath(filepath, root)
+            for stem in candidates:
                 if _is_referenced_in_content(stem, content):
                     for bin_path in stem_to_paths[stem]:
                         referenced_files.add(bin_path)
-                    rel_code = os.path.relpath(filepath, root)
                     match_details[stem] = rel_code
                     newly_matched.append(stem)
 
@@ -524,8 +545,8 @@ def find_unused_resources(
                 unmatched_stems.discard(stem)
 
     print(
-        f"Scanned {file_count} code files, matched {len(referenced_files)} "
-        f"resource files" + " " * 20
+        f"Scanned {file_count} code files, "
+        f"matched {len(referenced_files)}/{len(bin_files)} resource files" + " " * 20
     )
 
     unused_files = {

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -26,10 +26,10 @@ Usage:
     python check.py -d ./res -e bin --action delete
 
     # Find unused resources
-    python check.py --mode unused -c ./apps -r ./res
+    python check.py --mode unused -c ./apps -d ./res
 
     # Run both checks
-    python check.py --mode both -d ./res -c ./apps -r ./res -e bin
+    python check.py --mode both -d ./res -c ./apps -e bin
 """
 
 import argparse
@@ -739,8 +739,8 @@ def run_unused_mode(args):
         print(f"Error: Code path does not exist: {args.code}", file=sys.stderr)
         sys.exit(1)
 
-    if not os.path.isdir(args.resource):
-        print(f"Error: Resource path does not exist: {args.resource}", file=sys.stderr)
+    if not os.path.isdir(args.dir):
+        print(f"Error: Resource path does not exist: {args.dir}", file=sys.stderr)
         sys.exit(1)
 
     ignore_dirs = parse_ignore_dirs(args)
@@ -755,7 +755,7 @@ def run_unused_mode(args):
     print("=" * 60)
     print()
 
-    bin_files = scan_bin_files(args.resource, ignore_dirs)
+    bin_files = scan_bin_files(args.dir, ignore_dirs)
 
     print()
     print("Analyzing unused resources...")
@@ -772,7 +772,7 @@ def run_unused_mode(args):
         len(bin_files),
         total_size,
         os.path.abspath(args.code),
-        os.path.abspath(args.resource),
+        os.path.abspath(args.dir),
         ignore_dirs,
         output_file,
     )
@@ -844,7 +844,7 @@ def run_both_mode(args):
     unused_files = {}
     bin_files = {}
 
-    if args.code and args.resource:
+    if args.code:
         print()
         print("-" * 60)
         print("Step 2: Checking for unused resources...")
@@ -852,18 +852,13 @@ def run_both_mode(args):
 
         if not os.path.isdir(args.code):
             print(f"Warning: Code path does not exist: {args.code}", file=sys.stderr)
-        elif not os.path.isdir(args.resource):
-            print(
-                f"Warning: Resource path does not exist: {args.resource}",
-                file=sys.stderr,
-            )
         else:
             file_extensions: Set[str] = set(
                 ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}"
                 for ext in args.code_ext.split(",")
             )
 
-            bin_files = scan_bin_files(args.resource, ignore_dirs)
+            bin_files = scan_bin_files(args.dir, ignore_dirs)
             print()
             print("Analyzing unused resources...")
             unused_files, matched = find_unused_resources(
@@ -879,7 +874,7 @@ def run_both_mode(args):
     else:
         print()
         print("-" * 60)
-        print("Step 2: Skipped (no --code and --resource paths specified)")
+        print("Step 2: Skipped (no --code path specified)")
         print("-" * 60)
 
     # Step 3: Generate combined report
@@ -898,7 +893,7 @@ def run_both_mode(args):
         sum(size for _, size in bin_files.values()) if bin_files else 0,
         os.path.abspath(args.dir),
         os.path.abspath(args.code) if args.code else "",
-        os.path.abspath(args.resource) if args.resource else "",
+        os.path.abspath(args.dir),
         ignore_dirs,
         extensions,
         prefixes,
@@ -1106,11 +1101,11 @@ Examples:
   %(prog)s -d ./res -e bin --action delete
 
   # Find unused resources
-  %(prog)s --mode unused -c ./apps -r ./res
-  %(prog)s --mode unused -c ./apps -r ./res --prefix "/resource/app:"
+  %(prog)s --mode unused -c ./apps -d ./res
+  %(prog)s --mode unused -c ./apps -d ./res --prefix "/resource/app:"
 
   # Run both checks
-  %(prog)s --mode both -d ./res -c ./apps -r ./res -e bin
+  %(prog)s --mode both -d ./res -c ./apps -e bin
 
 Mode Description:
   dup     - Find duplicate files by content hash
@@ -1133,7 +1128,7 @@ Mode Description:
         "--dir",
         metavar="PATH",
         default=".",
-        help="Root directory to scan for duplicates (default: current directory)",
+        help="Target directory to scan (duplicates scan dir or resource dir, default: current directory)",
     )
     parser.add_argument(
         "-i",
@@ -1195,12 +1190,6 @@ Mode Description:
         help="Code directory to scan for .bin references (required for unused/both mode)",
     )
     parser.add_argument(
-        "-r",
-        "--resource",
-        metavar="PATH",
-        help="Resource directory containing .bin files (required for unused/both mode)",
-    )
-    parser.add_argument(
         "--code-ext",
         metavar="EXTS",
         default=".c,.h,.cpp,.hpp,.cc,.cxx,.py,.java,.js,.ts,.json",
@@ -1215,9 +1204,6 @@ Mode Description:
     if args.mode == "unused":
         if not args.code:
             print("Error: --code is required for unused mode", file=sys.stderr)
-            sys.exit(1)
-        if not args.resource:
-            print("Error: --resource is required for unused mode", file=sys.stderr)
             sys.exit(1)
 
     # Execute based on mode


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unify resource and scan paths into a single `-d/--dir` across all modes, add `-m` for mode, and speed up unused-resource detection with smarter, more accurate matching.

- **New Features**
  - Add `-m` as a short flag for `--mode`.
  - Faster unused-resource scan using a substring pre-filter and base-stem cache.
  - More accurate matches for numbered/padded filenames (e.g., `_Measuring234.bin` → `Measuring`; matches quoted and path contexts).
  - Output now shows matched/total resources.

- **Migration**
  - Replace `-r/--resource` with `-d/--dir` in all commands.
    - `--mode unused -c ./apps -r ./res` → `--mode unused -c ./apps -d ./res`
    - `--mode both -d ./res -c ./apps -r ./res` → `--mode both -d ./res -c ./apps`
  - Help text, examples, and validation updated to use `-d/--dir` only.

<sup>Written for commit 9a107a432f0012f63c90b7443bf875f08099dbb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

