### PR TITLE
Minor fix

### DIFF
--- a/miwear/__init__.py
+++ b/miwear/__init__.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.14"
+__version__ = "0.0.15"

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -392,12 +392,13 @@ def generate_dup_report(
 MIN_STEM_LENGTH_FOR_LOOSE_MATCH = 4
 
 
-def scan_bin_files(
-    resource_path: str, ignore_dirs: Set[str]
+def scan_resource_files(
+    resource_path: str, ignore_dirs: Set[str], extensions: Set[str]
 ) -> Dict[str, Tuple[str, int]]:
-    """Scan all .bin files in resource directory"""
-    bin_files: Dict[str, Tuple[str, int]] = {}
+    """Scan resource files with specified extensions in resource directory"""
+    resource_files: Dict[str, Tuple[str, int]] = {}
     root = Path(resource_path).resolve()
+    ext_desc = ", ".join(sorted(extensions))
 
     print(f"Scanning resource directory: {root}")
 
@@ -405,22 +406,24 @@ def scan_bin_files(
         dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
 
         for filename in filenames:
-            if filename.endswith(".bin"):
+            if any(filename.endswith(ext) for ext in extensions):
                 filepath = os.path.join(dirpath, filename)
                 try:
                     file_size = os.path.getsize(filepath)
                     rel_path = os.path.relpath(filepath, root)
-                    bin_files[rel_path] = (filepath, file_size)
+                    resource_files[rel_path] = (filepath, file_size)
                 except OSError as e:
                     print(
                         f"Warning: Cannot access file {filepath}: {e}", file=sys.stderr
                     )
 
-    print(f"Found {len(bin_files)} .bin files in resource directory")
-    return bin_files
+    print(f"Found {len(resource_files)} resource files ({ext_desc}) in resource directory")
+    return resource_files
 
 
-def _is_referenced_in_content(stem: str, content: str) -> bool:
+def _is_referenced_in_content(
+    stem: str, content: str, resource_exts: Set[str]
+) -> bool:
     """Check if a resource file stem is referenced in code content.
 
     Uses conservative matching strategy with multiple confidence levels.
@@ -428,15 +431,17 @@ def _is_referenced_in_content(stem: str, content: str) -> bool:
     on first hit.
 
     Args:
-        stem: resource filename without .bin extension (e.g. "reminder",
+        stem: resource filename without extension (e.g. "reminder",
               "anim0", "findphone_23")
         content: full text content of a code file
+        resource_exts: set of resource file extensions (e.g. {".bin"})
     """
 
-    # Rule 1 [HIGH]: exact "stem.bin" substring
+    # Rule 1 [HIGH]: exact "stem.ext" substring
     # e.g. code has: lv_img_set_src(img, "/res/reminder.bin");
-    if f"{stem}.bin" in content:
-        return True
+    for ext in resource_exts:
+        if f"{stem}{ext}" in content:
+            return True
 
     # Rule 2 [HIGH]: path separator before stem: "/stem"
     # e.g. code has: #define IMG OTA_PATH "/reminder"
@@ -485,12 +490,12 @@ def _is_referenced_in_content(stem: str, content: str) -> bool:
     if re.search(rf'"{re.escape(stem)}%[dsx0-9]', content):
         return True
 
-    # Rule 9 [LOW]: stem inside any quoted string AND ".bin" exists
-    # in the same file. Catches split-suffix patterns like:
+    # Rule 9 [LOW]: stem inside any quoted string AND resource extension
+    # exists in the same file. Catches split-suffix patterns like:
     # snprintf(path, "%s/fail.%s", dir, "bin");
     if (
         re.search(rf'["\'][^"\']*{re.escape(stem)}[^"\']*["\']', content)
-        and ".bin" in content
+        and any(ext in content for ext in resource_exts)
     ):
         return True
 
@@ -502,10 +507,11 @@ def find_unused_resources(
     code_path: str,
     ignore_dirs: Set[str],
     file_extensions: Set[str],
+    resource_exts: Set[str],
 ) -> Tuple[Dict[str, Tuple[str, int]], Dict[str, str]]:
     """Find unused resources using conservative filename-based matching.
 
-    For each .bin resource file, extract the stem (filename without .bin)
+    For each resource file, extract the stem (filename without extension)
     and search code files for references to that stem in string-literal
     contexts.
     """
@@ -575,7 +581,7 @@ def find_unused_resources(
             newly_matched = []
             rel_code = os.path.relpath(filepath, root)
             for stem in candidates:
-                if _is_referenced_in_content(stem, content):
+                if _is_referenced_in_content(stem, content, resource_exts):
                     for bin_path in stem_to_paths[stem]:
                         referenced_files.add(bin_path)
                     match_details[stem] = rel_code
@@ -603,17 +609,20 @@ def generate_unused_report(
     code_path: str,
     resource_path: str,
     ignore_dirs: Set[str],
+    extensions: Set[str],
     output_file: Optional[str] = None,
 ) -> str:
     """Generate unused resources report"""
+    ext_desc = ", ".join(sorted(extensions))
     lines = []
 
-    lines.append("# Unused .bin Resource File Report")
+    lines.append(f"# Unused Resource File Report ({ext_desc})")
     lines.append("")
     lines.append(f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
     lines.append(f"**Command**: `{' '.join(sys.argv)}`")
     lines.append(f"**Code Path**: `{code_path}`")
     lines.append(f"**Resource Path**: `{resource_path}`")
+    lines.append(f"**Resource Extensions**: {ext_desc}")
 
     if ignore_dirs:
         lines.append(
@@ -685,7 +694,7 @@ def generate_unused_report(
     lines.append("")
     lines.append("## 📋 Unused Files Detail")
     lines.append("")
-    lines.append(f"Found **{unused_count}** unused .bin files (sorted by size):")
+    lines.append(f"Found **{unused_count}** unused resource files (sorted by size):")
     lines.append("")
 
     for idx, (path, (_, size)) in enumerate(sorted_unused, 1):
@@ -798,23 +807,27 @@ def run_unused_mode(args):
         sys.exit(1)
 
     ignore_dirs = parse_ignore_dirs(args)
+    extensions = parse_extensions(args)
+    if not extensions:
+        extensions = {".bin"}
 
     file_extensions: Set[str] = set(
         ext.strip() if ext.strip().startswith(".") else f".{ext.strip()}"
         for ext in args.code_ext.split(",")
     )
 
+    ext_desc = ", ".join(sorted(extensions))
     print("=" * 60)
-    print("Unused .bin Resource File Detector")
+    print(f"Unused Resource File Detector ({ext_desc})")
     print("=" * 60)
     print()
 
-    bin_files = scan_bin_files(args.dir, ignore_dirs)
+    bin_files = scan_resource_files(args.dir, ignore_dirs, extensions)
 
     print()
     print("Analyzing unused resources...")
     unused_files, matched = find_unused_resources(
-        bin_files, args.code, ignore_dirs, file_extensions
+        bin_files, args.code, ignore_dirs, file_extensions, extensions
     )
 
     print()
@@ -828,6 +841,7 @@ def run_unused_mode(args):
         os.path.abspath(args.code),
         os.path.abspath(args.dir),
         ignore_dirs,
+        extensions,
         output_file,
     )
 
@@ -873,6 +887,7 @@ def run_both_mode(args):
     ignore_dirs = parse_ignore_dirs(args)
     extensions = parse_extensions(args)
     prefixes = parse_prefixes(args)
+    resource_exts = extensions if extensions else {".bin"}
 
     hash_to_files, total_files, total_size = scan_files_for_duplicates(
         args.dir, ignore_dirs, extensions, prefixes
@@ -912,16 +927,16 @@ def run_both_mode(args):
                 for ext in args.code_ext.split(",")
             )
 
-            bin_files = scan_bin_files(args.dir, ignore_dirs)
+            bin_files = scan_resource_files(args.dir, ignore_dirs, resource_exts)
             print()
             print("Analyzing unused resources...")
             unused_files, matched = find_unused_resources(
-                bin_files, args.code, ignore_dirs, file_extensions
+                bin_files, args.code, ignore_dirs, file_extensions, resource_exts
             )
 
             if unused_files:
                 unused_size = sum(size for _, size in unused_files.values())
-                print(f"Found {len(unused_files)} unused .bin files")
+                print(f"Found {len(unused_files)} unused resource files")
                 print(f"Unused size: {format_size(unused_size)}")
             else:
                 print("✅ All resource files are referenced!")
@@ -1106,7 +1121,7 @@ def generate_combined_report(
         else:
             unused_size = sum(size for _, size in unused_files.values())
 
-            lines.append(f"Found **{len(unused_files)}** unused .bin files:")
+            lines.append(f"Found **{len(unused_files)}** unused resource files:")
             lines.append("")
             lines.append(f"- Unused size: {format_size(unused_size)}")
             if resource_files > 0:
@@ -1164,7 +1179,7 @@ Examples:
 
 Mode Description:
   dup     - Find duplicate files by content hash
-  unused  - Find .bin resources not referenced in code
+  unused  - Find resources not referenced in code (default: .bin)
   both    - Run both checks in one command
         """,
     )
@@ -1243,7 +1258,7 @@ Mode Description:
         "-c",
         "--code",
         metavar="PATH",
-        help="Code directory to scan for .bin references (required for unused/both mode)",
+        help="Code directory to scan for resource references (required for unused/both mode)",
     )
     parser.add_argument(
         "--code-ext",

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -262,6 +262,7 @@ def generate_dup_report(
     lines.append("# Duplicate File Report")
     lines.append("")
     lines.append(f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"**Command**: `{' '.join(sys.argv)}`")
     lines.append(f"**Scanned Path**: `{root_path}`")
 
     if ignore_dirs:
@@ -610,6 +611,7 @@ def generate_unused_report(
     lines.append("# Unused .bin Resource File Report")
     lines.append("")
     lines.append(f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"**Command**: `{' '.join(sys.argv)}`")
     lines.append(f"**Code Path**: `{code_path}`")
     lines.append(f"**Resource Path**: `{resource_path}`")
 
@@ -1004,6 +1006,7 @@ def generate_combined_report(
     lines.append("# Resource Check Report - Full Analysis")
     lines.append("")
     lines.append(f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+    lines.append(f"**Command**: `{' '.join(sys.argv)}`")
     lines.append(f"**Scanned Path**: `{scan_path}`")
 
     if code_path:

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -201,8 +201,10 @@ def scan_files_for_duplicates(
     if prefixes:
         filter_desc += f" with prefixes {', '.join(prefixes)}"
 
-    print(f"Scan complete! Found {total_files} {filter_desc}, "
-          f"hashed {hashed_count} candidates" + " " * 20)
+    print(
+        f"Scan complete! Found {total_files} {filter_desc}, "
+        f"hashed {hashed_count} candidates" + " " * 20
+    )
     return hash_to_files, total_files, total_size
 
 
@@ -417,13 +419,13 @@ def scan_resource_files(
                         f"Warning: Cannot access file {filepath}: {e}", file=sys.stderr
                     )
 
-    print(f"Found {len(resource_files)} resource files ({ext_desc}) in resource directory")
+    print(
+        f"Found {len(resource_files)} resource files ({ext_desc}) in resource directory"
+    )
     return resource_files
 
 
-def _is_referenced_in_content(
-    stem: str, content: str, resource_exts: Set[str]
-) -> bool:
+def _is_referenced_in_content(stem: str, content: str, resource_exts: Set[str]) -> bool:
     """Check if a resource file stem is referenced in code content.
 
     Uses conservative matching strategy with multiple confidence levels.
@@ -493,9 +495,8 @@ def _is_referenced_in_content(
     # Rule 9 [LOW]: stem inside any quoted string AND resource extension
     # exists in the same file. Catches split-suffix patterns like:
     # snprintf(path, "%s/fail.%s", dir, "bin");
-    if (
-        re.search(rf'["\'][^"\']*{re.escape(stem)}[^"\']*["\']', content)
-        and any(ext in content for ext in resource_exts)
+    if re.search(rf'["\'][^"\']*{re.escape(stem)}[^"\']*["\']', content) and any(
+        ext in content for ext in resource_exts
     ):
         return True
 

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -128,14 +128,7 @@ def should_include_file(
                 has_prefix_match = True
                 break
 
-    if extensions and prefixes:
-        return has_ext_match and has_prefix_match
-    elif extensions:
-        return has_ext_match
-    elif prefixes:
-        return has_prefix_match
-    else:
-        return True
+    return has_ext_match and has_prefix_match
 
 
 def scan_files_for_duplicates(
@@ -144,8 +137,12 @@ def scan_files_for_duplicates(
     extensions: Set[str],
     prefixes: Set[str],
 ) -> Tuple[Dict[str, List[Tuple[str, int]]], int, int]:
-    """Scan files and calculate hash values"""
-    hash_to_files: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
+    """Scan files and calculate hash values.
+
+    Uses a size-based pre-filter: only files sharing the same size are
+    hashed, because files with unique sizes cannot be duplicates.
+    """
+    size_to_files: Dict[int, List[Tuple[str, str]]] = defaultdict(list)
     total_files = 0
     total_size = 0
     root = Path(root_path).resolve()
@@ -163,6 +160,7 @@ def scan_files_for_duplicates(
         print(f"Filtering by {', '.join(filter_info)}")
     print()
 
+    # Phase 1: collect files grouped by size
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
 
@@ -172,21 +170,30 @@ def scan_files_for_duplicates(
                 total_files += 1
 
                 if total_files % 500 == 0:
-                    print(f"Scanned {total_files} files...", end="\r")
+                    print(f"Scanned {total_files} files...", end="\r", flush=True)
 
                 try:
                     file_size = os.path.getsize(filepath)
                     total_size += file_size
-                    file_hash = calculate_file_hash(filepath)
-
-                    if file_hash:
-                        rel_path = os.path.relpath(filepath, root)
-                        hash_to_files[file_hash].append((rel_path, file_size))
+                    rel_path = os.path.relpath(filepath, root)
+                    size_to_files[file_size].append((rel_path, filepath))
                 except OSError as e:
                     print(
                         f"\nWarning: Unable to access file {filepath}: {e}",
                         file=sys.stderr,
                     )
+
+    # Phase 2: only hash files whose size appears more than once
+    hash_to_files: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
+    hashed_count = 0
+    for file_size, files in size_to_files.items():
+        if len(files) < 2:
+            continue
+        for rel_path, filepath in files:
+            file_hash = calculate_file_hash(filepath)
+            if file_hash:
+                hash_to_files[file_hash].append((rel_path, file_size))
+            hashed_count += 1
 
     filter_desc = "filtered files"
     if extensions:
@@ -194,7 +201,8 @@ def scan_files_for_duplicates(
     if prefixes:
         filter_desc += f" with prefixes {', '.join(prefixes)}"
 
-    print(f"Scan complete! Found {total_files} {filter_desc}" + " " * 20)
+    print(f"Scan complete! Found {total_files} {filter_desc}, "
+          f"hashed {hashed_count} candidates" + " " * 20)
     return hash_to_files, total_files, total_size
 
 
@@ -247,7 +255,7 @@ def generate_dup_report(
     ignore_dirs: Set[str],
     extensions: Set[str],
     prefixes: Set[str],
-    output_file: str | None = None,
+    output_file: Optional[str] = None,
 ) -> str:
     """Generate duplicate files report"""
     lines = []
@@ -539,7 +547,7 @@ def find_unused_resources(
             file_count += 1
 
             if file_count % 100 == 0:
-                print(f"Scanned {file_count} code files...", end="\r")
+                print(f"Scanned {file_count} code files...", end="\r", flush=True)
 
             try:
                 with open(filepath, "r", encoding="utf-8", errors="ignore") as f:
@@ -705,14 +713,6 @@ def generate_unused_report(
         print(f"\nReport saved to: {output_file}")
 
     return report
-
-
-def parse_prefix_mapping(mapping_str: str) -> Tuple[str, str]:
-    """Parse prefix mapping string like '/resource/app:/rgb888/app'"""
-    parts = mapping_str.split(":", 1)
-    if len(parts) == 2:
-        return parts[0].strip(), parts[1].strip()
-    return mapping_str.strip(), ""
 
 
 # ============ Mode Execution Functions ============

--- a/miwear/check.py
+++ b/miwear/check.py
@@ -414,49 +414,71 @@ def scan_bin_files(
 def _is_referenced_in_content(stem: str, content: str) -> bool:
     """Check if a resource file stem is referenced in code content.
 
-    Uses conservative matching strategy:
-    - High confidence: "stem.bin", '/stem', stem.bin in any quote context
-    - Medium confidence: /stem%, "stem" in quotes, stem as path component
-    - Short stems (<=3 chars): require exact quoted or path match
-    - Numbered stems (e.g. anim0): also try base name with format specifier
+    Uses conservative matching strategy with multiple confidence levels.
+    Matching rules are ordered from high to low confidence, returns True
+    on first hit.
+
+    Args:
+        stem: resource filename without .bin extension (e.g. "reminder",
+              "anim0", "findphone_23")
+        content: full text content of a code file
     """
 
-    # High confidence: exact filename with .bin extension
+    # Rule 1 [HIGH]: exact "stem.bin" substring
+    # e.g. code has: lv_img_set_src(img, "/res/reminder.bin");
     if f"{stem}.bin" in content:
         return True
 
-    # High confidence: path separator + stem (e.g. /reminder, /fail)
+    # Rule 2 [HIGH]: path separator before stem: "/stem"
+    # e.g. code has: #define IMG OTA_PATH "/reminder"
     if f"/{stem}" in content:
         return True
 
-    # Medium confidence: quoted stem (e.g. "reminder", 'fail')
+    # Rule 3 [MEDIUM]: stem wrapped in quotes: "stem" or 'stem'
+    # e.g. code has: dsc.name = "reminder";
     if f'"{stem}"' in content or f"'{stem}'" in content:
         return True
 
-    # Numbered stem: Measuring45 -> base_stem "Measuring"
-    # Matches: "Measuring%d", "Measuring%02d", "/Measuring", '"Measuring"'
-    # Covers both format-string patterns and prefix_name/suffix_name patterns
-    # like: dsc.prefix_name = "/path/Measuring"; dsc.suffix_name = ".bin";
+    # Rule 4-7: numbered file handling
+    # For files like anim0.bin, Measuring45.bin, findphone_23.bin,
+    # strip trailing digits to get base_stem (anim, Measuring,
+    # findphone_), then try matching with base_stem
     base_stem = re.sub(r"\d+$", "", stem)
     if base_stem and base_stem != stem:
+        # Rule 4 [MEDIUM]: path separator before base_stem: "/base_stem"
+        # e.g. code has: prefix_name = MAKE_PATH("/measure/Measuring");
         if f"/{base_stem}" in content:
             return True
+
+        # Rule 5 [MEDIUM]: base_stem wrapped in quotes
+        # e.g. code has: dsc.prefix = "Measuring";
         if f'"{base_stem}"' in content or f"'{base_stem}'" in content:
             return True
+
+        # Rule 6 [MEDIUM]: base_stem followed by format specifier
+        # e.g. code has: snprintf(path, "%s/anim%d.bin", dir, idx);
         if re.search(rf'["\'/]{re.escape(base_stem)}%[dsx0-9]', content):
             return True
 
-    # Short stems need stricter matching - stop here
+        # Rule 7 [MEDIUM]: base_stem as standalone word (len >= 4)
+        # e.g. code has: APP_ANIM_PATH(findphone_)
+        #      or:       #define PREFIX findphone_
+        if len(base_stem) >= 4 and re.search(rf"\b{re.escape(base_stem)}\b", content):
+            return True
+
+    # Short stems (<=3 chars like "ab", "ok") are too common as
+    # variable/function names, stop here to avoid false positives
     if len(stem) < MIN_STEM_LENGTH_FOR_LOOSE_MATCH:
         return False
 
-    # Medium confidence: stem followed by format specifier
-    # Catches: "anim%d.bin", "icon%s", "frame%02d"
+    # Rule 8 [LOW]: stem followed by format specifier
+    # e.g. code has: snprintf(path, "icon%s", suffix);
     if re.search(rf'"{re.escape(stem)}%[dsx0-9]', content):
         return True
 
-    # Medium confidence: stem in a string with .bin nearby
-    # Catches: snprintf(path, "%s/fail.%s", dir, "bin")
+    # Rule 9 [LOW]: stem inside any quoted string AND ".bin" exists
+    # in the same file. Catches split-suffix patterns like:
+    # snprintf(path, "%s/fail.%s", dir, "bin");
     if (
         re.search(rf'["\'][^"\']*{re.escape(stem)}[^"\']*["\']', content)
         and ".bin" in content


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speeds up duplicate detection and expands unused resource scanning to support custom extensions, with clearer matching and more informative reports. Bumps version to 0.0.15 and fixes a lint error.

- **New Features**
  - `unused` now respects `-e/--ext` to scan specified resource extensions (defaults to `.bin`).
  - Generalized scanner to `scan_resource_files`; reports show scanned extensions and the full command used.
  - Improved reference matching with explicit rules (incl. numbered stems and word-boundary matches) to reduce misses.

- **Performance**
  - Duplicate scan hashes only files that share the same size; shows count of hashed candidates.
  - Smoother progress output (flush), simplified include-file filtering, removed dead code, and unified `Optional[str]` annotations.

<sup>Written for commit e5e2009d8447853b894cc0aca979c7dec9b702a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

