### PR TITLE
docs: update README with miwear_check and miwear_ymodem tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@ A comprehensive Python Miwear toolkit to extract and process archive log files.
 
 - Supports batch extraction of `.tar.gz` , `.zip` and `.gz` files.
 - Command-line tools for log processing, validation, merging and unzipping.
+- Resource check tool for finding duplicate files and unused resources.
 - Serial command sender for interacting with serial devices (requires `pyserial`).
+- YMODEM file transfer over serial port (requires `pyserial`).
 - Designed for automation and integration into your workflow.
-- No external dependencies for log processing tools (pure Python standard libraries).
-- `pyserial` required for serial communication functionality.
+- Requires Python >= 3.10.
+- No external dependencies for log processing and resource check tools (pure Python standard libraries).
+- `pyserial` required for serial communication and YMODEM functionality.
 
 ## Installation
 
@@ -43,6 +46,8 @@ After installation, you get several standalone CLI tools:
 - `miwear_tz` : Specialized extraction for `.tar.gz`.
 - `miwear_uz` : Versatile archive decompression utility.
 - `miwear_serial` : Serial command sender for interacting with serial devices (requires `pyserial`).
+- `miwear_ymodem` : YMODEM file transfer over serial port (requires `pyserial`).
+- `miwear_check` : Resource check tool for finding duplicate files and unused resources.
 
 ## Usage Examples
 
@@ -90,7 +95,47 @@ miwear_tz --path ./logs
 miwear_uz --path ./logs
 ```
 
-### 6. Serial Command Sender
+### 6. Resource Check Tool
+
+**Find duplicate files (default mode):**
+
+```bash
+miwear_check -d ./res -e bin
+```
+
+**Find duplicate files and delete duplicates:**
+
+```bash
+miwear_check -d ./res -e bin --action delete
+```
+
+**Find unused resources:**
+
+```bash
+miwear_check -m unused -c ./apps -d ./res
+```
+
+**Find unused resources with path prefix mapping:**
+
+```bash
+miwear_check -m unused -c ./apps -d ./res --prefix "/resource/app:"
+```
+
+**Run both checks (duplicate + unused):**
+
+```bash
+miwear_check -m both -d ./res -c ./apps -e bin
+```
+
+### 7. YMODEM File Transfer
+
+Transfer a file via YMODEM over serial port:
+
+```bash
+miwear_ymodem -p /dev/ttyACM0 -b 921600 -f firmware.bin
+```
+
+### 8. Serial Command Sender
 
 The `miwear_serial` tool requires the `pyserial` library. Install it with:
 


### PR DESCRIPTION
docs: update README with miwear_check and miwear_ymodem tools

Add documentation for the new miwear_check resource check tool
(duplicate detection, unused resource scanning) and miwear_ymodem
YMODEM file transfer tool. Update Python version requirement to
>= 3.10 and reorganize the usage examples section.

Signed-off-by: Junbo Zheng <3273070@qq.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README to add docs for `miwear_check` (resource checks) and `miwear_ymodem` (YMODEM over serial), raise the Python requirement to >= 3.10, and reorder usage examples for clarity.

- **New Features**
  - Documented `miwear_check` with examples for duplicate and unused resource scanning.
  - Documented `miwear_ymodem` with a send example.
  - Updated CLI tool list and clarified `pyserial` needs for serial/YMODEM.

- **Migration**
  - Requires Python >= 3.10.
  - Install `pyserial` to use `miwear_serial` and `miwear_ymodem`.

<sup>Written for commit a08b552307cca91a2dc897cf8f5ac15b62429810. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

