### PR TITLE
add miwear_extract CLI to pull files by extension from ZIP archives without full extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,13 @@
-name: Python Linting
+name: CI
 
 on:
   push:
     branches: [main, master]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
@@ -15,12 +19,12 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 black mypy pytest
+          pip install flake8 black mypy
 
       - name: Run flake8
         run: flake8 . --count --show-source --statistics
@@ -30,6 +34,27 @@ jobs:
 
       - name: Run mypy
         run: mypy miwear/ --ignore-missing-imports
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
 
       - name: Run pytest
         run: python -m pytest tests/ -v
@@ -45,9 +70,6 @@ jobs:
 
       - name: Run unzip.py for test
         run: ./miwear/unzip.py --path tests/data
-
-      - name: Run check
-        run: cat 123.log
 
       - name: Run md5sum
         run: md5sum -c tests/data/123.md5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install build backend
+        run: pip install build
+
+      - name: Build distribution
+        run: python -m build
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ miwear_check -d ./resources -e bin
 | `miwear_gz`          | Decompress and merge `.gz` log shards                                      |
 | `miwear_tz`          | Batch-extract every `.tar.gz` archive in a directory                       |
 | `miwear_uz`          | Batch-extract every `.zip` archive in a directory                          |
+| `miwear_extract`     | Pull files with specific extensions out of a ZIP archive                   |
 | `miwear_check`       | Resource audit — duplicates, unused assets, directory diff                 |
 | `miwear_loganalyzer` | Parse AppID / screen log patterns into CSV or interactive HTML             |
 | `miwear_serial`      | Serial console helper (requires `pyserial`)                                |
@@ -107,6 +108,18 @@ Batch-extract every archive in a directory.
 ```bash
 miwear_tz --path ./logs     # *.tar.gz
 miwear_uz --path ./logs     # *.zip
+```
+
+### `miwear_extract`
+
+Pull files with specific extensions out of a ZIP archive into an output directory, without performing a full extraction. If no ZIP is given, the current directory is scanned and you pick one interactively.
+
+```bash
+# Auto-detect a ZIP in the current directory, extract *.bin (default)
+miwear_extract
+
+# Explicit archive, multiple extensions, custom output directory
+miwear_extract firmware.zip -e bin hex -o ./out
 ```
 
 ### `miwear_check`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Python toolkit for extracting, merging, auditing and analyzing MiWear device d
 [![Python](https://img.shields.io/pypi/pyversions/miwear.svg)](https://pypi.org/project/miwear/)
 [![License](https://img.shields.io/pypi/l/miwear.svg)](./LICENSE)
 [![Downloads](https://img.shields.io/pypi/dm/miwear.svg)](https://pypi.org/project/miwear/)
-[![CI](https://github.com/Junbo-Zheng/OpenMiwear/actions/workflows/lint.yml/badge.svg)](https://github.com/Junbo-Zheng/OpenMiwear/actions/workflows/lint.yml)
+[![CI](https://github.com/Junbo-Zheng/OpenMiwear/actions/workflows/ci.yml/badge.svg)](https://github.com/Junbo-Zheng/OpenMiwear/actions/workflows/ci.yml)
 
 </div>
 
@@ -263,7 +263,9 @@ pip install flake8 black mypy pytest
 ./build.sh
 ```
 
-`build.sh` runs `flake8`, `black --check`, `mypy`, `pytest`, and then exercises each CLI against the fixtures in `tests/data/`. GitHub Actions runs the same steps on every push and pull request via [`.github/workflows/lint.yml`](./.github/workflows/lint.yml).
+`build.sh` runs `flake8`, `black --check`, `mypy`, `pytest`, and then exercises each CLI against the fixtures in `tests/data/`. GitHub Actions mirrors this on every push and pull request via [`.github/workflows/ci.yml`](./.github/workflows/ci.yml), with the `test` job running against a Python 3.10 / 3.11 / 3.12 / 3.13 matrix.
+
+Releases are automated through [`.github/workflows/publish.yml`](./.github/workflows/publish.yml): publishing a GitHub Release triggers a build and uploads the distribution to PyPI via OIDC trusted publishing — no API tokens involved.
 
 > [!NOTE]
 > The repository on GitHub is `Junbo-Zheng/OpenMiwear`, but the PyPI distribution and Python import/command names use the shorter **`miwear`** identifier (e.g. `import miwear`, `miwear_log …`). This is intentional — keep the project name **OpenMiwear** when referring to the repo, and the package name `miwear` when invoking the tools.

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ miwear_uz --path ./logs     # *.zip
 Pull files with specific extensions out of a ZIP archive into an output directory, without performing a full extraction. If no ZIP is given, the current directory is scanned and you pick one interactively.
 
 ```bash
-# Auto-detect a ZIP in the current directory, extract *.bin (default)
+# Auto-detect a ZIP in the current directory, extract *.elf (default)
 miwear_extract
 
 # Explicit archive, multiple extensions, custom output directory

--- a/miwear/__init__.py
+++ b/miwear/__init__.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/miwear/extract.py
+++ b/miwear/extract.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# -*- coding:UTF-8 -*-
+#
+# Copyright (C) 2026 Junbo Zheng. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import glob
+import zipfile
+import argparse
+import os
+from typing import List
+
+try:
+    from miwear import __version__
+except ImportError:
+    __version__ = "0.0.1"
+
+
+def select_interactive(items: List[str]) -> int:
+    """Arrow-key inline selector. Returns chosen index."""
+    import sys
+    import tty
+    import termios
+    import shutil
+
+    cur = 0
+    total = len(items)
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    out = sys.stdout
+    cols = shutil.get_terminal_size().columns
+
+    def display_lines() -> int:
+        """Calculate total display lines considering wrapping."""
+        count = 0
+        for item in items:
+            line_len = len(item) + 2  # ">" or " " + space + item
+            count += max(1, (line_len + cols - 1) // cols)
+        return count
+
+    def render(first: bool = False) -> None:
+        lines = display_lines()
+        if not first:
+            out.write(f"\033[{lines}A")
+        for i, item in enumerate(items):
+            if i == cur:
+                out.write(f"\033[1;32m> {item}\033[0m\033[K\n")
+            else:
+                out.write(f"  {item}\033[K\n")
+        out.flush()
+
+    def readkey() -> bytes:
+        ch = os.read(fd, 1)
+        if ch == b"\x1b":
+            ch += os.read(fd, 1)
+            ch += os.read(fd, 1)
+        return ch
+
+    try:
+        tty.setcbreak(fd)
+        out.write("\033[?25l")
+        out.flush()
+        render(first=True)
+        while True:
+            key = readkey()
+            if key in (b"\r", b"\n"):
+                break
+            elif key == b"\x1b[A" and cur > 0:
+                cur -= 1
+            elif key == b"\x1b[B" and cur < total - 1:
+                cur += 1
+            elif key == b"\x03":
+                raise KeyboardInterrupt
+            else:
+                continue
+            render()
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        out.write("\033[?25h")
+        out.flush()
+
+    return cur
+
+
+def find_zip_file(path: str) -> str:
+    """Find a zip file in the given directory. Prompt user if multiple."""
+    zip_files = sorted(glob.glob(os.path.join(path, "*.zip")))
+    if not zip_files:
+        print(f"No ZIP files found in '{os.path.abspath(path)}'.")
+        raise SystemExit(1)
+    if len(zip_files) == 1:
+        print(f"Found: {os.path.basename(zip_files[0])}")
+        return zip_files[0]
+
+    names = [os.path.basename(f) for f in zip_files]
+    print(f"Found {len(zip_files)} ZIP files (↑↓ to select, Enter to confirm):")
+    idx = select_interactive(names)
+    print(f"Selected: {names[idx]}")
+    return zip_files[idx]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract files with specific extensions from a ZIP archive "
+        "into the current directory."
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
+        "zipfile",
+        type=str,
+        nargs="?",
+        default=None,
+        help="Path to the ZIP file (auto-detects in current directory if omitted)",
+    )
+    parser.add_argument(
+        "-e",
+        "--ext",
+        type=str,
+        nargs="+",
+        default=["bin"],
+        help="File extensions to extract (default: bin)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        default=".",
+        help="Output directory (default: current directory)",
+    )
+
+    args = parser.parse_args()
+
+    if args.zipfile is None:
+        args.zipfile = find_zip_file(".")
+    elif not os.path.isfile(args.zipfile):
+        print(f"Error: '{args.zipfile}' does not exist or is not a file.")
+        return
+
+    # Normalize extensions (strip leading dots)
+    extensions: List[str] = [ext.lstrip(".").lower() for ext in args.ext]
+
+    try:
+        with zipfile.ZipFile(args.zipfile, "r") as zf:
+            matched = [
+                name
+                for name in zf.namelist()
+                if not name.endswith("/")
+                and name.rsplit(".", 1)[-1].lower() in extensions
+            ]
+
+            if not matched:
+                print(
+                    f"No files with extension(s) "
+                    f"{', '.join('.' + e for e in extensions)} "
+                    f"found in '{args.zipfile}'."
+                )
+                return
+
+            os.makedirs(args.output, exist_ok=True)
+
+            print(
+                f"Extracting {len(matched)} file(s) with extension(s) "
+                f"{', '.join('.' + e for e in extensions)} "
+                f"to '{os.path.abspath(args.output)}':"
+            )
+
+            for name in matched:
+                basename = os.path.basename(name)
+                target = os.path.join(args.output, basename)
+                with zf.open(name) as src, open(target, "wb") as dst:
+                    dst.write(src.read())
+                print(f"  {basename}")
+
+            print("Done!")
+
+    except zipfile.BadZipFile:
+        print(f"Error: '{args.zipfile}' is not a valid ZIP file.")
+    except PermissionError:
+        print(f"Error: Permission denied for '{args.zipfile}'.")
+    except Exception as e:
+        print(f"Error: {str(e)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/miwear/extract.py
+++ b/miwear/extract.py
@@ -133,8 +133,8 @@ def main() -> None:
         "--ext",
         type=str,
         nargs="+",
-        default=["bin"],
-        help="File extensions to extract (default: bin)",
+        default=["elf"],
+        help="File extensions to extract (default: elf)",
     )
     parser.add_argument(
         "-o",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ miwear_assert = "miwear.assert:main"
 miwear_serial = "miwear.serialtool:main"
 miwear_check = "miwear.check:main"
 miwear_loganalyzer = "miwear.loganalyzer:main"
+miwear_extract = "miwear.extract:main"
 
 [tool.setuptools]
 packages = { find = {} }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `miwear_extract` CLI to pull files by extension from ZIP archives without full extraction, and improve CI with split lint/test, Python 3.10–3.13 testing, and a PyPI publish workflow. Docs updated and `miwear` bumped to 0.0.21.

- **New Features**
  - `miwear_extract`: extract only matching extensions from a ZIP (default `.elf`) into an output directory.
  - Supports `-e` for multiple extensions and `-o` for output dir; auto-detects a ZIP and offers an interactive picker if multiple are found.

- **CI & Release**
  - Rename workflow to `ci.yml`; split into `lint` (Python 3.12) and `test` (3.10–3.13), enable concurrency, remove stray debug step.
  - Add `publish.yml` to build and publish to PyPI on GitHub Release via OIDC (no API token).
  - Update README badge/links and add `miwear_extract` docs; register the `miwear_extract` entry point in `pyproject.toml`.

<sup>Written for commit 07f36854ea898ab30b790cb33bd73366e0486726. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

