### PR TITLE
bump version to 0.0.22.

### DIFF
--- a/miwear/__init__.py
+++ b/miwear/__init__.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"

--- a/miwear/extract.py
+++ b/miwear/extract.py
@@ -23,76 +23,20 @@ import os
 from collections import defaultdict
 from typing import Dict, List
 
+import questionary
+
 try:
     from miwear import __version__
 except ImportError:
     __version__ = "0.0.1"
 
 
-def select_interactive(items: List[str]) -> int:
-    """Arrow-key inline selector. Returns chosen index."""
-    import sys
-    import tty
-    import termios
-    import shutil
-
-    cur = 0
-    total = len(items)
-    fd = sys.stdin.fileno()
-    old = termios.tcgetattr(fd)
-    out = sys.stdout
-    cols = shutil.get_terminal_size().columns
-
-    def display_lines() -> int:
-        """Calculate total display lines considering wrapping."""
-        count = 0
-        for item in items:
-            line_len = len(item) + 2  # ">" or " " + space + item
-            count += max(1, (line_len + cols - 1) // cols)
-        return count
-
-    def render(first: bool = False) -> None:
-        lines = display_lines()
-        if not first:
-            out.write(f"\033[{lines}A")
-        for i, item in enumerate(items):
-            if i == cur:
-                out.write(f"\033[1;32m> {item}\033[0m\033[K\n")
-            else:
-                out.write(f"  {item}\033[K\n")
-        out.flush()
-
-    def readkey() -> bytes:
-        ch = os.read(fd, 1)
-        if ch == b"\x1b":
-            ch += os.read(fd, 1)
-            ch += os.read(fd, 1)
-        return ch
-
-    try:
-        tty.setcbreak(fd)
-        out.write("\033[?25l")
-        out.flush()
-        render(first=True)
-        while True:
-            key = readkey()
-            if key in (b"\r", b"\n"):
-                break
-            elif key == b"\x1b[A" and cur > 0:
-                cur -= 1
-            elif key == b"\x1b[B" and cur < total - 1:
-                cur += 1
-            elif key == b"\x03":
-                raise KeyboardInterrupt
-            else:
-                continue
-            render()
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old)
-        out.write("\033[?25h")
-        out.flush()
-
-    return cur
+def select_interactive(items: List[str], message: str = "Select:") -> int:
+    """Arrow-key selector backed by questionary. Returns chosen index."""
+    answer = questionary.select(message, choices=items).ask()
+    if answer is None:
+        raise SystemExit(1)
+    return items.index(answer)
 
 
 def find_zip_file(path: str) -> str:
@@ -106,8 +50,7 @@ def find_zip_file(path: str) -> str:
         return zip_files[0]
 
     names = [os.path.basename(f) for f in zip_files]
-    print(f"Found {len(zip_files)} ZIP files (↑↓ to select, Enter to confirm):")
-    idx = select_interactive(names)
+    idx = select_interactive(names, f"Found {len(zip_files)} ZIP files:")
     print(f"Selected: {names[idx]}")
     return zip_files[idx]
 
@@ -195,11 +138,10 @@ def main() -> None:
                     selected.append(names[0])
                     continue
                 names.sort(key=conflict_sort_key)
-                print(
-                    f"\n'{basename}' exists in {len(names)} locations "
-                    f"(↑↓ to select, Enter to confirm):"
+                idx = select_interactive(
+                    names,
+                    f"'{basename}' exists in {len(names)} locations:",
                 )
-                idx = select_interactive(names)
                 print(f"Selected: {names[idx]}")
                 selected.append(names[idx])
 

--- a/miwear/extract.py
+++ b/miwear/extract.py
@@ -20,7 +20,8 @@ import glob
 import zipfile
 import argparse
 import os
-from typing import List
+from collections import defaultdict
+from typing import Dict, List
 
 try:
     from miwear import __version__
@@ -157,11 +158,16 @@ def main() -> None:
 
     try:
         with zipfile.ZipFile(args.zipfile, "r") as zf:
+            # Always include 'ota.zip' (strict basename match) regardless
+            # of --ext, so the OTA package is extracted alongside elf/bin/etc.
             matched = [
                 name
                 for name in zf.namelist()
                 if not name.endswith("/")
-                and name.rsplit(".", 1)[-1].lower() in extensions
+                and (
+                    name.rsplit(".", 1)[-1].lower() in extensions
+                    or os.path.basename(name) == "ota.zip"
+                )
             ]
 
             if not matched:
@@ -172,20 +178,45 @@ def main() -> None:
                 )
                 return
 
+            # Group by basename to detect same-name conflicts across folders.
+            groups: Dict[str, List[str]] = defaultdict(list)
+            for name in matched:
+                groups[os.path.basename(name)].append(name)
+
+            # Sort key: place the "base" parent dir first (no '_' suffix
+            # variant like 'audio' before 'audio_test'/'audio_performance_test').
+            def conflict_sort_key(path: str) -> tuple:
+                parent = os.path.basename(os.path.dirname(path))
+                return (parent.count("_"), len(parent), parent)
+
+            selected: List[str] = []
+            for basename, names in groups.items():
+                if len(names) == 1:
+                    selected.append(names[0])
+                    continue
+                names.sort(key=conflict_sort_key)
+                print(
+                    f"\n'{basename}' exists in {len(names)} locations "
+                    f"(↑↓ to select, Enter to confirm):"
+                )
+                idx = select_interactive(names)
+                print(f"Selected: {names[idx]}")
+                selected.append(names[idx])
+
             os.makedirs(args.output, exist_ok=True)
 
             print(
-                f"Extracting {len(matched)} file(s) with extension(s) "
+                f"\nExtracting {len(selected)} file(s) with extension(s) "
                 f"{', '.join('.' + e for e in extensions)} "
                 f"to '{os.path.abspath(args.output)}':"
             )
 
-            for name in matched:
+            for name in selected:
                 basename = os.path.basename(name)
                 target = os.path.join(args.output, basename)
                 with zf.open(name) as src, open(target, "wb") as dst:
                     dst.write(src.read())
-                print(f"  {basename}")
+                print(f"  {basename}  (from {name})")
 
             print("Done!")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-dependencies = []
+dependencies = ["questionary>=2.0"]
 requires-python = ">=3.10"
 
 [project.optional-dependencies]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve `miwear_extract` to always include `ota.zip` and resolve same-name file conflicts with an interactive choice. Replace the custom TTY selector with `questionary`; bump version to 0.0.22.

- **New Features**
  - Always extract `ota.zip` alongside files matched by `--ext`.
  - When the same basename appears in multiple folders, prompt to choose one (sorted to prefer the base parent dir without “_” suffix).

- **Dependencies**
  - Add `questionary>=2.0` for the interactive selector (replaces the termios-based implementation).

<sup>Written for commit c386a075df0d81fe3f252851d07c5ff0213db73e. Summary will update on new commits. <a href="https://cubic.dev/pr/Junbo-Zheng/OpenMiwear/pull/92?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

