### PR TITLE
miwear: rename extract to ez and add precise target filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ miwear_check -d ./resources -e bin
 | `miwear_gz`          | Decompress and merge `.gz` log shards                                      |
 | `miwear_tz`          | Batch-extract every `.tar.gz` archive in a directory                       |
 | `miwear_uz`          | Batch-extract every `.zip` archive in a directory                          |
-| `miwear_extract`     | Pull files with specific extensions out of a ZIP archive                   |
+| `miwear_ez`          | Pull files out of a ZIP archive by precise filename-stem suffix            |
 | `miwear_check`       | Resource audit — duplicates, unused assets, directory diff                 |
 | `miwear_loganalyzer` | Parse AppID / screen log patterns into CSV or interactive HTML             |
 | `miwear_serial`      | Serial console helper (requires `pyserial`)                                |
@@ -110,16 +110,22 @@ miwear_tz --path ./logs     # *.tar.gz
 miwear_uz --path ./logs     # *.zip
 ```
 
-### `miwear_extract`
+### `miwear_ez`
 
-Pull files with specific extensions out of a ZIP archive into an output directory, without performing a full extraction. If no ZIP is given, the current directory is scanned and you pick one interactively.
+Pull files out of a ZIP archive into an output directory, without performing a full extraction. Files are selected by a precise filename-stem suffix: `ap` matches `*ap.elf` but **not** `*app.elf`. Pass `all` to extract everything. If no ZIP is given, the current directory is scanned and you pick one interactively.
 
 ```bash
-# Auto-detect a ZIP in the current directory, extract *.elf (default)
-miwear_extract
+# Auto-detect a ZIP, extract *ap.elf (default target is 'ap')
+miwear_ez
+
+# Extract every *.elf (legacy behavior), plus ota.zip
+miwear_ez all
+
+# A different stem suffix, e.g. *cp.elf
+miwear_ez cp
 
 # Explicit archive, multiple extensions, custom output directory
-miwear_extract firmware.zip -e bin hex -o ./out
+miwear_ez ap firmware.zip -e bin hex -o ./out
 ```
 
 ### `miwear_check`

--- a/miwear/__init__.py
+++ b/miwear/__init__.py
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"

--- a/miwear/ez.py
+++ b/miwear/ez.py
@@ -57,13 +57,23 @@ def find_zip_file(path: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Extract files with specific extensions from a ZIP archive "
-        "into the current directory."
+        description="Extract files from a ZIP archive into the current directory, "
+        "filtered by a precise filename-stem suffix (e.g. 'ap' matches "
+        "'*ap.elf' but not '*app.elf'). Use 'all' to extract everything."
     )
     parser.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
+    )
+    parser.add_argument(
+        "target",
+        type=str,
+        nargs="?",
+        default="ap",
+        help="Filename-stem suffix to match precisely, e.g. 'ap' selects "
+        "'*ap.elf' but not '*app.elf'; 'all' extracts every file "
+        "(default: ap)",
     )
     parser.add_argument(
         "zipfile",
@@ -96,28 +106,36 @@ def main() -> None:
         print(f"Error: '{args.zipfile}' does not exist or is not a file.")
         return
 
-    # Normalize extensions (strip leading dots)
+    # Normalize extensions (strip leading dots) and the target stem suffix.
     extensions: List[str] = [ext.lstrip(".").lower() for ext in args.ext]
+    target: str = args.target.lower()
+    extract_all: bool = target == "all"
+
+    def matches(name: str) -> bool:
+        if name.endswith("/"):
+            return False
+        ext_ok = name.rsplit(".", 1)[-1].lower() in extensions
+        if extract_all:
+            # 'all' restores the legacy behavior: every file matching --ext,
+            # plus the OTA package regardless of its extension.
+            return ext_ok or os.path.basename(name) == "ota.zip"
+        # Precise stem-suffix match: target 'ap' selects '*ap.elf' but NOT
+        # '*app.elf', because 'app'.endswith('ap') is False.
+        stem = os.path.splitext(os.path.basename(name))[0]
+        return ext_ok and stem.endswith(target)
+
+    def selection_desc() -> str:
+        if extract_all:
+            return f"extension(s) {', '.join('.' + e for e in extensions)}"
+        return f"stem suffix '{target}' (e.g. '*{target}.{extensions[0]}')"
 
     try:
         with zipfile.ZipFile(args.zipfile, "r") as zf:
-            # Always include 'ota.zip' (strict basename match) regardless
-            # of --ext, so the OTA package is extracted alongside elf/bin/etc.
-            matched = [
-                name
-                for name in zf.namelist()
-                if not name.endswith("/")
-                and (
-                    name.rsplit(".", 1)[-1].lower() in extensions
-                    or os.path.basename(name) == "ota.zip"
-                )
-            ]
+            matched = [name for name in zf.namelist() if matches(name)]
 
             if not matched:
                 print(
-                    f"No files with extension(s) "
-                    f"{', '.join('.' + e for e in extensions)} "
-                    f"found in '{args.zipfile}'."
+                    f"No files matching {selection_desc()} found in '{args.zipfile}'."
                 )
                 return
 
@@ -148,8 +166,8 @@ def main() -> None:
             os.makedirs(args.output, exist_ok=True)
 
             print(
-                f"\nExtracting {len(selected)} file(s) with extension(s) "
-                f"{', '.join('.' + e for e in extensions)} "
+                f"\nExtracting {len(selected)} file(s) matching "
+                f"{selection_desc()} "
                 f"to '{os.path.abspath(args.output)}':"
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ miwear_assert = "miwear.assert:main"
 miwear_serial = "miwear.serialtool:main"
 miwear_check = "miwear.check:main"
 miwear_loganalyzer = "miwear.loganalyzer:main"
-miwear_extract = "miwear.extract:main"
+miwear_ez = "miwear.ez:main"
 
 [tool.setuptools]
 packages = { find = {} }


### PR DESCRIPTION
miwear: rename extract to ez and add precise target filter

Rename the extract command to ez (miwear/extract.py -> miwear/ez.py, entry point miwear_extract -> miwear_ez) and add a positional target argument that selects files by a precise filename-stem suffix: 'ap' matches '*ap.elf' but not '*app.elf', while 'all' restores the legacy behavior of extracting every file plus ota.zip. The target defaults to 'ap' to avoid pulling out the full set of large artifacts by default. Also bump version to 0.0.23.

Assisted-by: Claude (claude-opus-4-8) <claude@anthropic.com>
Signed-off-by: Junbo Zheng <3273070@qq.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the ZIP extractor CLI to `miwear_ez` and added a precise filename-stem target filter. Default target `ap` extracts only `*ap.elf`; use `all` to keep the previous “extract everything + ota.zip” behavior.

- New Features
  - New CLI: `miwear_ez` (was `miwear_extract`); moved `miwear/extract.py` to `miwear/ez.py`.
  - Added positional `target` for exact stem-suffix matching; default `ap`; `all` extracts all plus `ota.zip`.
  - Updated README and `pyproject.toml` entry point; version bumped to `0.0.23`.

- Migration
  - Replace `miwear_extract` with `miwear_ez`.
  - For legacy behavior, run `miwear_ez all`.

<sup>Written for commit 57938807c2ac63e36da00872efeac5fc0e018c0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Junbo-Zheng/OpenMiwear/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

